### PR TITLE
Batch subscriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+- New feature: allow subscription to process events in batches. You can now provide `in_batches: true` to `#subscribe` to yield an array of events. See [docs](docs/subscriptions.md#processing-events-in-batches) for more info
+
 ## [2.0.0]
 
 - **Breaking change**: `pg_eventstore` now requires [pg_cron](https://github.com/citusdata/pg_cron) extension

--- a/docs/subscriptions.md
+++ b/docs/subscriptions.md
@@ -126,9 +126,27 @@ subscriptions_manager.subscribe(
   # overrides config.failed_subscription_notifier
   failed_subscription_notifier: proc { |_subscription, err| p err },
   # overrides config.subscription_graceful_shutdown_timeout
-  graceful_shutdown_timeout: 20
+  graceful_shutdown_timeout: 20,
+  # Yield array of events into your handler instead a single event. See example bellow.
+  in_batches: true
 )
 ```
+
+## Processing events in batches
+
+There is an ability to tell the subscription to yield an array of events it pulled last time. The number of events is the implementation-wide(current implementation may yield up to 1k events) and can't be adjusted. Example:
+
+```ruby
+subscriptions_manager.subscribe(
+  'MyAwesomeSubscription',
+  handler: proc { |events| puts events }, # => outputs array of events
+  in_batches: true
+)
+```
+
+In this case the subscription's position will be advanced to the position of the last event of the chunk. Please note that in case of failure: 
+- the whole chunk will be yielded again during subscription retries phase
+- new events may appear in the chunk between retries
 
 ## Middlewares
 

--- a/docs/subscriptions.md
+++ b/docs/subscriptions.md
@@ -134,7 +134,7 @@ subscriptions_manager.subscribe(
 
 ## Processing events in batches
 
-There is an ability to tell the subscription to yield an array of events it pulled last time. The number of events is the implementation-wide(current implementation may yield up to 1k events) and can't be adjusted. Example:
+There is an ability to tell the subscription to yield an array of events it pulled last time. The number of events is the implementation specific(current implementation may yield up to 1k events) and can't be adjusted. Example:
 
 ```ruby
 subscriptions_manager.subscribe(

--- a/lib/pg_eventstore/event_deserializer.rb
+++ b/lib/pg_eventstore/event_deserializer.rb
@@ -4,13 +4,13 @@ module PgEventstore
   # @!visibility private
   class EventDeserializer
     # @!attribute middlewares
-    #   @return [Array<#deserialize, #serialize>]
+    #   @return [Array<Middleware>]
     attr_reader :middlewares
     # @!attribute event_class_resolver
     #   @return [#call]
     attr_reader :event_class_resolver
 
-    # @param middlewares [Array<Object<#deserialize, #serialize>>]
+    # @param middlewares [Array<Middleware>]
     # @param event_class_resolver [#call]
     def initialize(middlewares, event_class_resolver)
       @middlewares = middlewares

--- a/lib/pg_eventstore/subscriptions/callback_handlers/events_processor_handlers.rb
+++ b/lib/pg_eventstore/subscriptions/callback_handlers/events_processor_handlers.rb
@@ -6,25 +6,13 @@ module PgEventstore
     include Extensions::CallbackHandlersExtension
 
     class << self
+      # @param consumer [PgEventstore::EventsProcessorConsumer]
       # @param callbacks [PgEventstore::Callbacks]
-      # @param handler [#call]
       # @param raw_events [Array<Hash>]
       # @param raw_events_cond [MonitorMixin::ConditionVariable]
       # @return [void]
-      def process_event(callbacks, handler, raw_events, raw_events_cond)
-        raw_event = nil
-        raw_events.synchronize do
-          raw_events_cond.wait(0.5) if raw_events.empty?
-          raw_event = raw_events.shift
-        end
-        return if raw_event.nil?
-
-        callbacks.run_callbacks(:process, Utils.original_global_position(raw_event)) do
-          handler.call(raw_event)
-        rescue => exception
-          raw_events.unshift(raw_event)
-          raise Utils.wrap_exception(exception, global_position: Utils.original_global_position(raw_event))
-        end
+      def consume_events(consumer, callbacks, raw_events, raw_events_cond)
+        consumer.call(callbacks, raw_events, raw_events_cond)
       end
 
       # @param callbacks [PgEventstore::Callbacks]

--- a/lib/pg_eventstore/subscriptions/events_processor.rb
+++ b/lib/pg_eventstore/subscriptions/events_processor.rb
@@ -10,12 +10,12 @@ module PgEventstore
     def_delegators :@basic_runner, :state, :start, :stop, :wait_for_finish, :stop_async, :restore, :running?,
                    :within_state
 
-    # @param handler [#call]
     # @param graceful_shutdown_timeout [Integer, Float] seconds. Determines how long to wait before force-shutdown
     #   the runner when stopping it using #stop_async
+    # @param consumer [PgEventstore::EventsProcessorConsumer]
     # @param recovery_strategies [Array<PgEventstore::RunnerRecoveryStrategy>]
-    def initialize(handler, graceful_shutdown_timeout:, recovery_strategies: [])
-      @handler = handler
+    def initialize(graceful_shutdown_timeout:, consumer:, recovery_strategies: [])
+      @consumer = consumer
       @raw_events = SynchronizedArray.new
       @raw_events_cond = @raw_events.new_cond
       @basic_runner = BasicRunner.new(
@@ -56,7 +56,7 @@ module PgEventstore
     def attach_runner_callbacks
       @basic_runner.define_callback(
         :process_async, :before,
-        EventsProcessorHandlers.setup_handler(:process_event, @callbacks, @handler, @raw_events, @raw_events_cond)
+        EventsProcessorHandlers.setup_handler(:consume_events, @consumer, @callbacks, @raw_events, @raw_events_cond)
       )
 
       @basic_runner.define_callback(

--- a/lib/pg_eventstore/subscriptions/events_processor_consumer.rb
+++ b/lib/pg_eventstore/subscriptions/events_processor_consumer.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module PgEventstore
+  # @!visibility private
+  module EventsProcessorConsumer
+    class << self
+      def consumer_class(in_batches)
+        return Multiple if in_batches
+
+        Single
+      end
+
+      def included(othermod)
+        othermod.extend(ClassMethods)
+        super
+      end
+    end
+
+    module ClassMethods
+      def create_consumer(handler, deserializer)
+        raise NotImplementedError
+      end
+    end
+
+    # @param callbacks [PgEventstore::Callbacks]
+    # @param raw_events [Array<Hash>]
+    # @param raw_events_cond [MonitorMixin::ConditionVariable]
+    # @return [void]
+    def call(callbacks, raw_events, raw_events_cond)
+      raise NotImplementedError
+    end
+  end
+end
+
+require_relative 'events_processor_consumer/single'
+require_relative 'events_processor_consumer/multiple'

--- a/lib/pg_eventstore/subscriptions/events_processor_consumer/multiple.rb
+++ b/lib/pg_eventstore/subscriptions/events_processor_consumer/multiple.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module PgEventstore
+  module EventsProcessorConsumer
+    # @!visibility private
+    class Multiple
+      include EventsProcessorConsumer
+
+      class << self
+        def create_consumer(handler, deserializer)
+          raw_handler = ->(raw_events) { handler.call(raw_events.map(&deserializer.method(:deserialize))) }
+          new(raw_handler)
+        end
+      end
+
+      # @param handler [#call]
+      def initialize(handler)
+        @handler = handler
+      end
+
+      # @param callbacks [PgEventstore::Callbacks]
+      # @param raw_events [Array<Hash>]
+      # @param raw_events_cond [MonitorMixin::ConditionVariable]
+      def call(callbacks, raw_events, raw_events_cond)
+        events_to_process = []
+        raw_events.synchronize do
+          raw_events_cond.wait(0.5) if raw_events.empty?
+          events_to_process = raw_events.slice!(0..)
+        end
+        return if events_to_process.empty?
+
+        callbacks.run_callbacks(:process, Utils.original_global_position(events_to_process.last)) do
+          @handler.call(events_to_process)
+        rescue => exception
+          raw_events.unshift(*events_to_process)
+          raise Utils.wrap_exception(
+            exception, global_positions: events_to_process.map(&Utils.method(:original_global_position))
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/pg_eventstore/subscriptions/events_processor_consumer/single.rb
+++ b/lib/pg_eventstore/subscriptions/events_processor_consumer/single.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module PgEventstore
+  module EventsProcessorConsumer
+    # @!visibility private
+    class Single
+      include EventsProcessorConsumer
+
+      class << self
+        def create_consumer(handler, deserializer)
+          raw_handler = ->(raw_event) { handler.call(deserializer.deserialize(raw_event)) }
+          new(raw_handler)
+        end
+      end
+
+      # @param handler [#call]
+      def initialize(handler)
+        @handler = handler
+      end
+
+      # @param callbacks [PgEventstore::Callbacks]
+      # @param raw_events [PgEventstore::SynchronizedArray]
+      # @param raw_events_cond [MonitorMixin::ConditionVariable]
+      def call(callbacks, raw_events, raw_events_cond)
+        raw_event = nil
+        raw_events.synchronize do
+          raw_events_cond.wait(0.5) if raw_events.empty?
+          raw_event = raw_events.shift
+        end
+        return if raw_event.nil?
+
+        callbacks.run_callbacks(:process, Utils.original_global_position(raw_event)) do
+          @handler.call(raw_event)
+        rescue => exception
+          raw_events.unshift(raw_event)
+          raise Utils.wrap_exception(exception, global_position: Utils.original_global_position(raw_event))
+        end
+      end
+    end
+  end
+end

--- a/lib/pg_eventstore/subscriptions/subscriptions_manager.rb
+++ b/lib/pg_eventstore/subscriptions/subscriptions_manager.rb
@@ -7,6 +7,7 @@ require_relative 'runner_recovery_strategy'
 require_relative 'runner_recovery_strategies'
 require_relative 'subscription'
 require_relative 'synchronized_array'
+require_relative 'events_processor_consumer'
 require_relative 'events_processor'
 require_relative 'subscription_handler_performance'
 require_relative 'subscription_runner'
@@ -91,6 +92,7 @@ module PgEventstore
     #   notification about failed subscription.
     # @param graceful_shutdown_timeout [integer, Float] the number of seconds to wait until force-shutdown the
     #   subscription during the stop process
+    # @param in_batches [Boolean] whether a batch of events should be yielded instead a single event
     # @return [void]
     def subscribe(subscription_name, handler:, options: {}, middlewares: nil,
                   pull_interval: config.subscription_pull_interval,
@@ -98,16 +100,18 @@ module PgEventstore
                   retries_interval: config.subscription_retries_interval,
                   restart_terminator: config.subscription_restart_terminator,
                   failed_subscription_notifier: config.failed_subscription_notifier,
-                  graceful_shutdown_timeout: config.subscription_graceful_shutdown_timeout)
+                  graceful_shutdown_timeout: config.subscription_graceful_shutdown_timeout,
+                  in_batches: false)
       subscription = Subscription.using_connection(config.name).new(
         set: @set_name, name: subscription_name, options:, chunk_query_interval: pull_interval,
         max_restarts_number: max_retries, time_between_restarts: retries_interval
       )
+      consumer_class = EventsProcessorConsumer.consumer_class(in_batches)
       runner = SubscriptionRunner.new(
         stats: SubscriptionHandlerPerformance.new,
         events_processor: EventsProcessor.new(
-          create_raw_event_handler(middlewares, handler),
           graceful_shutdown_timeout:,
+          consumer: consumer_class.create_consumer(handler, deserializer(middlewares)),
           recovery_strategies: recovery_strategies(subscription, restart_terminator, failed_subscription_notifier)
         ),
         subscription:
@@ -157,12 +161,8 @@ module PgEventstore
       PgEventstore::CLI.callbacks.run_callbacks(:start_manager, self, &)
     end
 
-    # @param middlewares [Array<Symbol>, nil]
-    # @param handler [#call]
-    # @return [Proc]
-    def create_raw_event_handler(middlewares, handler)
-      deserializer = EventDeserializer.new(select_middlewares(middlewares), config.event_class_resolver)
-      ->(raw_event) { handler.call(deserializer.deserialize(raw_event)) }
+    def deserializer(middlewares)
+      EventDeserializer.new(select_middlewares(middlewares), config.event_class_resolver)
     end
 
     # @param middlewares [Array, nil]

--- a/sig/interfaces/_raw_events_handler.rbs
+++ b/sig/interfaces/_raw_events_handler.rbs
@@ -1,0 +1,3 @@
+interface _RawEventsHandler
+  def call: (Array[Hash[String, untyped]] events) -> void
+end

--- a/sig/interfaces/subscription_handler.rbs
+++ b/sig/interfaces/subscription_handler.rbs
@@ -1,3 +1,3 @@
 interface _SubscriptionHandler
-  def call: (PgEventstore::Event event) -> void
+  def call: (PgEventstore::Event | Array[PgEventstore::Event] event) -> void
 end

--- a/sig/pg_eventstore/event_deserializer.rbs
+++ b/sig/pg_eventstore/event_deserializer.rbs
@@ -3,17 +3,17 @@ module PgEventstore
     # _@param_ `middlewares`
     #
     # _@param_ `event_class_resolver`
-    def initialize: (::Array[PgEventstore::Middleware] middlewares, _EventClassResolver event_class_resolver) -> void
+    def initialize: (::Array[Middleware] middlewares, _EventClassResolver event_class_resolver) -> void
 
     # _@param_ `raw_events`
-    def deserialize_many: (::Array[::Hash[untyped, untyped]] raw_events) -> ::Array[PgEventstore::Event]
+    def deserialize_many: (::Array[::Hash[untyped, untyped]] raw_events) -> ::Array[Event]
 
     # _@param_ `attrs`
-    def deserialize: (::Hash[untyped, untyped] attrs) -> PgEventstore::Event
+    def deserialize: (::Hash[untyped, untyped] attrs) -> Event
 
-    def without_middlewares: () -> PgEventstore::EventDeserializer
+    def without_middlewares: () -> EventDeserializer
 
-    attr_accessor middlewares: ::Array[PgEventstore::Middleware]
+    attr_accessor middlewares: ::Array[Middleware]
 
     attr_accessor event_class_resolver: _EventClassResolver
   end

--- a/sig/pg_eventstore/subscriptions/callback_handlers/events_processor_handlers.rbs
+++ b/sig/pg_eventstore/subscriptions/callback_handlers/events_processor_handlers.rbs
@@ -1,12 +1,12 @@
 module PgEventstore
   class EventsProcessorHandlers
-    def self.process_event: (PgEventstore::Callbacks callbacks, _RawEventHandler handler, SynchronizedArray raw_events,
+    def self.consume_events: (EventsProcessorConsumer consumer, Callbacks callbacks, SynchronizedArray raw_events,
         MonitorMixin::ConditionVariable raw_events_cond) -> void
 
-    def self.after_runner_died: (PgEventstore::Callbacks callbacks, StandardError error) -> void
+    def self.after_runner_died: (Callbacks callbacks, StandardError error) -> void
 
-    def self.before_runner_restored: (PgEventstore::Callbacks callbacks) -> void
+    def self.before_runner_restored: (Callbacks callbacks) -> void
 
-    def self.change_state: (PgEventstore::Callbacks callbacks, String state) -> void
+    def self.change_state: (Callbacks callbacks, String state) -> void
   end
 end

--- a/sig/pg_eventstore/subscriptions/events_processor.rbs
+++ b/sig/pg_eventstore/subscriptions/events_processor.rbs
@@ -1,11 +1,11 @@
 module PgEventstore
   class EventsProcessor
-    include PgEventstore::Extensions::CallbacksExtension
+    include Extensions::CallbacksExtension
     extend Forwardable
 
     %a{rbs:test:skip} def initialize: (
-        _RawEventHandler handler,
         graceful_shutdown_timeout: Float | Integer,
+        consumer: EventsProcessorConsumer,
         ?recovery_strategies: Array[RunnerRecoveryStrategy]
       ) -> void
 

--- a/sig/pg_eventstore/subscriptions/events_processor_consumer.rbs
+++ b/sig/pg_eventstore/subscriptions/events_processor_consumer.rbs
@@ -1,0 +1,12 @@
+module PgEventstore
+  module EventsProcessorConsumer
+    module ClassMethods
+      def create_consumer: (_SubscriptionHandler handler, EventDeserializer deserializer) -> EventsProcessorConsumer
+    end
+
+    def self.consumer_class: (bool in_batches) -> Class
+
+    def call: (Callbacks callbacks, SynchronizedArray raw_events,
+        MonitorMixin::ConditionVariable raw_events_cond) -> void
+  end
+end

--- a/sig/pg_eventstore/subscriptions/events_processor_consumer/multiple.rbs
+++ b/sig/pg_eventstore/subscriptions/events_processor_consumer/multiple.rbs
@@ -1,0 +1,13 @@
+module PgEventstore
+  module EventsProcessorConsumer
+    class Multiple
+      include EventsProcessorConsumer
+      extend ClassMethods
+
+      @handler: _RawEventsHandler
+
+      def initialize: (_RawEventsHandler handler) -> void
+    end
+  end
+end
+

--- a/sig/pg_eventstore/subscriptions/events_processor_consumer/single.rbs
+++ b/sig/pg_eventstore/subscriptions/events_processor_consumer/single.rbs
@@ -1,0 +1,13 @@
+module PgEventstore
+  module EventsProcessorConsumer
+    class Single
+      include EventsProcessorConsumer
+      extend ClassMethods
+
+      @handler: _RawEventHandler
+
+      def initialize: (_RawEventHandler handler) -> void
+    end
+  end
+end
+

--- a/sig/pg_eventstore/subscriptions/subscriptions_manager.rbs
+++ b/sig/pg_eventstore/subscriptions/subscriptions_manager.rbs
@@ -3,21 +3,14 @@ module PgEventstore
     extend Forwardable
 
     @set_name: String
-    @subscription_feeder: PgEventstore::SubscriptionFeeder
-    @subscriptions_lifecycle: PgEventstore::SubscriptionsLifecycle
-    @subscriptions_set_lifecycle: PgEventstore::SubscriptionsSetLifecycle
+    @subscription_feeder: SubscriptionFeeder
+    @subscriptions_lifecycle: SubscriptionsLifecycle
+    @subscriptions_set_lifecycle: SubscriptionsSetLifecycle
 
-    def self.callbacks: () -> PgEventstore::Callbacks
+    def self.callbacks: () -> Callbacks
 
-    # _@param_ `config`
-    #
-    # _@param_ `set_name`
-    #
-    # _@param_ `max_retries` — max number of retries of failed SubscriptionsSet
-    #
-    # _@param_ `retries_interval` — a delay between retries of failed SubscriptionsSet
     def initialize: (
-        config: PgEventstore::Config,
+        config: Config,
         set_name: String,
         ?max_retries: Integer?,
         ?retries_interval: Integer?,
@@ -26,23 +19,6 @@ module PgEventstore
 
     def config_name: () -> Symbol
 
-    # _@param_ `subscription_name` — subscription's name
-    #
-    # _@param_ `handler` — subscription's handler
-    #
-    # _@param_ `options` — request options
-    #
-    # _@param_ `middlewares` — provide a list of middleware names to override a config's middlewares
-    #
-    # _@param_ `pull_interval` — an interval in seconds to determine how often to query new events of the given subscription.
-    #
-    # _@param_ `max_retries` — max number of retries of failed Subscription
-    #
-    # _@param_ `retries_interval` — a delay between retries of failed Subscription
-    #
-    # _@param_ `restart_terminator` — a callable object which is invoked with PgEventstore::Subscription instance to determine whether restarts should be stopped(true - stops restarts, false - continues restarts)
-    #
-    # _@param_ `failed_subscription_notifier` - a callable object which is invoked with PgEventstore::Subscription instance and error instance after the related subscription died due to error and no longer can be automatically restarted due to max retries number reached. You can use this hook to send a notification about failed subscription.
     def subscribe: (
         String subscription_name,
         handler: _SubscriptionHandler,
@@ -54,26 +30,22 @@ module PgEventstore
         ?restart_terminator: _RestartTerminator?,
         ?failed_subscription_notifier: _FailedSubscriptionNotifier?,
         ?graceful_shutdown_timeout: Integer | Float,
+        ?in_batches: bool,
       ) -> void
 
-    def subscriptions: () -> ::Array[PgEventstore::Subscription]
+    def subscriptions: () -> ::Array[Subscription]
 
-    def subscriptions_set: () -> PgEventstore::SubscriptionsSet?
+    def subscriptions_set: () -> SubscriptionsSet?
 
-    # _@param_ `middlewares`
-    #
-    # _@param_ `handler`
-    def create_raw_event_handler: (::Array[Symbol]? middlewares, _SubscriptionHandler handler) -> _RawEventHandler
+    def deserializer: (::Array[Symbol]? middlewares) -> EventDeserializer
 
-    # _@param_ `middlewares`
-    def select_middlewares: (?::Array[Symbol]? middlewares) -> ::Array[PgEventstore::Middleware]
+    def select_middlewares: (?::Array[Symbol]? middlewares) -> ::Array[Middleware]
 
-    def start!: () -> PgEventstore::BasicRunner
+    def start!: () -> BasicRunner
 
-    def start: () -> PgEventstore::BasicRunner?
+    def start: () -> BasicRunner?
 
-    # Returns the value of attribute config.
-    attr_accessor config: PgEventstore::Config
+    attr_accessor config: Config
 
     private
 

--- a/spec/pg_eventstore/subscriptions/callback_handlers/events_processor_handlers_spec.rb
+++ b/spec/pg_eventstore/subscriptions/callback_handlers/events_processor_handlers_spec.rb
@@ -3,151 +3,20 @@
 RSpec.describe PgEventstore::EventsProcessorHandlers do
   it { is_expected.to be_a(PgEventstore::Extensions::CallbackHandlersExtension) }
 
-  describe '.process_event' do
-    subject { described_class.process_event(callbacks, handler, raw_events, raw_events_cond) }
+  describe '.consume_events' do
+    subject { described_class.consume_events(consumer, callbacks, raw_events, raw_events_cond) }
 
     let(:callbacks) { PgEventstore::Callbacks.new }
-    let(:handler) { proc { |raw_event| raw_event_handler.call(raw_event) } }
-    let(:raw_event_handler) { double('RawEventHandler') }
-    let(:raw_events) { PgEventstore::SynchronizedArray.new }
+    let(:consumer) do
+      PgEventstore::EventsProcessorConsumer::Single.new(proc { |raw_event| processed_events.push(raw_event) })
+    end
+    let(:raw_events) { PgEventstore::SynchronizedArray.new([raw_event]) }
+    let(:raw_event) { { 'global_position' => 1 } }
     let(:raw_events_cond) { raw_events.new_cond }
-    let(:on_process_cbx) do
-      proc do |action, global_position|
-        position_handler_before.call(global_position)
-        action.call
-        position_handler_after.call(global_position)
-      end
-    end
-    let(:position_handler_before) { double('PositionHandlerBefore') }
-    let(:position_handler_after) { double('PositionHandlerAfter') }
+    let(:processed_events) { [] }
 
-    before do
-      callbacks.define_callback(:process, :around, on_process_cbx)
-      allow(position_handler_before).to receive(:call)
-      allow(position_handler_after).to receive(:call)
-      allow(raw_event_handler).to receive(:call)
-    end
-
-    context 'when no events are given' do
-      it 'sleeps for .5 seconds' do
-        expect { subject }.to change { Time.now }.by(be_between(0.5, 0.51))
-      end
-      it 'does not run :process callbacks' do
-        subject
-        aggregate_failures do
-          expect(position_handler_before).not_to have_received(:call)
-          expect(position_handler_after).not_to have_received(:call)
-        end
-      end
-      it 'does not process any event' do
-        subject
-        expect(raw_event_handler).not_to have_received(:call)
-      end
-    end
-
-    context 'when there are some events' do
-      let(:raw_events) { PgEventstore::SynchronizedArray.new([raw_event1, raw_event2]) }
-      let(:raw_event1) { { 'global_position' => 123 } }
-      let(:raw_event2) { { 'global_position' => 125 } }
-
-      it 'does not sleep' do
-        expect { subject }.to change { Time.now }.by(be_between(0, 0.01))
-      end
-      it 'runs :process callbacks for first event' do
-        subject
-        aggregate_failures do
-          expect(position_handler_before).to have_received(:call).with(raw_event1['global_position'])
-          expect(position_handler_after).to have_received(:call).with(raw_event1['global_position'])
-        end
-      end
-      it 'does not run :process callbacks for second event' do
-        subject
-        aggregate_failures do
-          expect(position_handler_before).not_to have_received(:call).with(raw_event2['global_position'])
-          expect(position_handler_after).not_to have_received(:call).with(raw_event2['global_position'])
-        end
-      end
-      it 'processes first event' do
-        subject
-        expect(raw_event_handler).to have_received(:call).with(raw_event1)
-      end
-      it 'does not process second event' do
-        subject
-        expect(raw_event_handler).not_to have_received(:call).with(raw_event2)
-      end
-      it 'removes processed event from the list' do
-        expect { subject }.to change { raw_events }.to([raw_event2])
-      end
-    end
-
-    context 'when handler raises an error' do
-      let(:raw_events) { PgEventstore::SynchronizedArray.new([raw_event1, raw_event2]) }
-      let(:raw_event1) { { 'global_position' => 123 } }
-      let(:raw_event2) { { 'global_position' => 125 } }
-
-      let(:handler) { proc { raise error_class, 'Oops!' } }
-      let(:error_class) { Class.new(StandardError) }
-
-      it 'does not sleep' do
-        expect {
-          begin
-            subject
-          rescue PgEventstore::WrappedException
-          end
-        }.to change { Time.now }.by(be_between(0, 0.01))
-      end
-      it 'does not process any event' do
-        begin
-          subject
-        rescue PgEventstore::WrappedException
-        end
-        expect(raw_event_handler).not_to have_received(:call)
-      end
-      it 'runs only :before :process callbacks' do
-        begin
-          subject
-        rescue PgEventstore::WrappedException
-        end
-        aggregate_failures do
-          expect(position_handler_before).to have_received(:call).with(raw_event1['global_position'])
-          expect(position_handler_after).not_to have_received(:call)
-        end
-      end
-      it 'does not remove first event from the list' do
-        expect {
-          begin
-            subject
-          rescue PgEventstore::WrappedException
-          end
-        }.not_to change { raw_events }
-      end
-      # rubocop:disable RSpec/MultipleExpectations
-      it 'raises the error' do
-        expect { subject }.to raise_error(PgEventstore::WrappedException) do |error|
-          aggregate_failures do
-            expect(error.original_exception).to be_a(error_class)
-            expect(error.original_exception.message).to eq('Oops!')
-            expect(error.extra).to eq(global_position: raw_event1['global_position'])
-          end
-        end
-      end
-      # rubocop:enable RSpec/MultipleExpectations
-
-      context 'when event which caused an exception is a link event' do
-        let(:raw_event1) { { 'global_position' => 123, 'link' => { 'global_position' => 321 } } }
-
-        # rubocop:disable RSpec/MultipleExpectations
-        it 'raises the error with correct global position' do
-          expect { subject }.to raise_error(PgEventstore::WrappedException) do |error|
-            aggregate_failures do
-              expect(error.original_exception).to be_a(error_class)
-              expect(error.original_exception.message).to eq('Oops!')
-              expect(error.extra).to eq(global_position: raw_event1['link']['global_position'])
-            end
-          end
-        end
-        # rubocop:enable RSpec/MultipleExpectations
-      end
+    it 'processes given events' do
+      expect { subject }.to change { processed_events }.to([raw_event])
     end
   end
 

--- a/spec/pg_eventstore/subscriptions/callback_handlers/events_processor_handlers_spec.rb
+++ b/spec/pg_eventstore/subscriptions/callback_handlers/events_processor_handlers_spec.rb
@@ -10,13 +10,32 @@ RSpec.describe PgEventstore::EventsProcessorHandlers do
     let(:consumer) do
       PgEventstore::EventsProcessorConsumer::Single.new(proc { |raw_event| processed_events.push(raw_event) })
     end
-    let(:raw_events) { PgEventstore::SynchronizedArray.new([raw_event]) }
-    let(:raw_event) { { 'global_position' => 1 } }
+    let(:raw_events) { PgEventstore::SynchronizedArray.new([raw_event1, raw_event2]) }
+    let(:raw_event1) { { 'global_position' => 1 } }
+    let(:raw_event2) { { 'global_position' => 2 } }
     let(:raw_events_cond) { raw_events.new_cond }
     let(:processed_events) { [] }
 
-    it 'processes given events' do
-      expect { subject }.to change { processed_events }.to([raw_event])
+    context 'when consumer is Single' do
+      it 'processes first event in the queue' do
+        expect { subject }.to change { processed_events }.to([raw_event1])
+      end
+      it 'removes processed event from the queue' do
+        expect { subject }.to change { raw_events }.to([raw_event2])
+      end
+    end
+
+    context 'when consumer is Multiple' do
+      let(:consumer) do
+        PgEventstore::EventsProcessorConsumer::Multiple.new(proc { |raw_events| processed_events.push(raw_events) })
+      end
+
+      it 'processes all events in the queue' do
+        expect { subject }.to change { processed_events }.to([[raw_event1, raw_event2]])
+      end
+      it 'removes processed events from the queue' do
+        expect { subject }.to change { raw_events }.to([])
+      end
     end
   end
 

--- a/spec/pg_eventstore/subscriptions/callback_handlers/subscription_feeder_handlers_spec.rb
+++ b/spec/pg_eventstore/subscriptions/callback_handlers/subscription_feeder_handlers_spec.rb
@@ -35,7 +35,9 @@ RSpec.describe PgEventstore::SubscriptionFeederHandlers do
     let(:subscription_runner1) do
       PgEventstore::SubscriptionRunner.new(
         stats: PgEventstore::SubscriptionHandlerPerformance.new,
-        events_processor: PgEventstore::EventsProcessor.new(proc {}, graceful_shutdown_timeout: 0),
+        events_processor: PgEventstore::EventsProcessor.new(
+          consumer: PgEventstore::EventsProcessorConsumer::Single.new(proc {}), graceful_shutdown_timeout: 0
+        ),
         subscription: subscription1
       )
     end
@@ -43,7 +45,9 @@ RSpec.describe PgEventstore::SubscriptionFeederHandlers do
     let(:subscription_runner2) do
       PgEventstore::SubscriptionRunner.new(
         stats: PgEventstore::SubscriptionHandlerPerformance.new,
-        events_processor: PgEventstore::EventsProcessor.new(proc {}, graceful_shutdown_timeout: 0),
+        events_processor: PgEventstore::EventsProcessor.new(
+          consumer: PgEventstore::EventsProcessorConsumer::Single.new(proc {}), graceful_shutdown_timeout: 0
+        ),
         subscription: subscription2
       )
     end
@@ -88,14 +92,18 @@ RSpec.describe PgEventstore::SubscriptionFeederHandlers do
     let(:subscription_runner1) do
       PgEventstore::SubscriptionRunner.new(
         stats: PgEventstore::SubscriptionHandlerPerformance.new,
-        events_processor: PgEventstore::EventsProcessor.new(proc {}, graceful_shutdown_timeout: 0),
+        events_processor: PgEventstore::EventsProcessor.new(
+          consumer: PgEventstore::EventsProcessorConsumer::Single.new(proc {}), graceful_shutdown_timeout: 0
+        ),
         subscription: SubscriptionsHelper.create_with_connection(set: 'Foo', name: 'Bar')
       )
     end
     let(:subscription_runner2) do
       PgEventstore::SubscriptionRunner.new(
         stats: PgEventstore::SubscriptionHandlerPerformance.new,
-        events_processor: PgEventstore::EventsProcessor.new(proc {}, graceful_shutdown_timeout: 0),
+        events_processor: PgEventstore::EventsProcessor.new(
+          consumer: PgEventstore::EventsProcessorConsumer::Single.new(proc {}), graceful_shutdown_timeout: 0
+        ),
         subscription: SubscriptionsHelper.create_with_connection(set: 'Foo', name: 'Baz')
       )
     end
@@ -210,7 +218,8 @@ RSpec.describe PgEventstore::SubscriptionFeederHandlers do
       PgEventstore::SubscriptionRunner.new(
         stats: PgEventstore::SubscriptionHandlerPerformance.new,
         events_processor: PgEventstore::EventsProcessor.new(
-          proc { |event| precessed_events1.push(event) }, graceful_shutdown_timeout: 0
+          consumer: PgEventstore::EventsProcessorConsumer::Single.new(proc { |event| precessed_events1.push(event) }),
+          graceful_shutdown_timeout: 0
         ),
         subscription: SubscriptionsHelper.create_with_connection(
           set: 'Foo',
@@ -223,7 +232,8 @@ RSpec.describe PgEventstore::SubscriptionFeederHandlers do
       PgEventstore::SubscriptionRunner.new(
         stats: PgEventstore::SubscriptionHandlerPerformance.new,
         events_processor: PgEventstore::EventsProcessor.new(
-          proc { |event| precessed_events2.push(event) }, graceful_shutdown_timeout: 0
+          consumer: PgEventstore::EventsProcessorConsumer::Single.new(proc { |event| precessed_events2.push(event) }),
+          graceful_shutdown_timeout: 0
         ),
         subscription: SubscriptionsHelper.create_with_connection(
           set: 'Foo',
@@ -282,7 +292,9 @@ RSpec.describe PgEventstore::SubscriptionFeederHandlers do
     let(:subscription_runner1) do
       PgEventstore::SubscriptionRunner.new(
         stats: PgEventstore::SubscriptionHandlerPerformance.new,
-        events_processor: PgEventstore::EventsProcessor.new(proc {}, graceful_shutdown_timeout: 0),
+        events_processor: PgEventstore::EventsProcessor.new(
+          consumer: PgEventstore::EventsProcessorConsumer::Single.new(proc {}), graceful_shutdown_timeout: 0
+        ),
         subscription: subscription1
       )
     end
@@ -294,7 +306,9 @@ RSpec.describe PgEventstore::SubscriptionFeederHandlers do
     let(:subscription_runner2) do
       PgEventstore::SubscriptionRunner.new(
         stats: PgEventstore::SubscriptionHandlerPerformance.new,
-        events_processor: PgEventstore::EventsProcessor.new(proc {}, graceful_shutdown_timeout: 0),
+        events_processor: PgEventstore::EventsProcessor.new(
+          consumer: PgEventstore::EventsProcessorConsumer::Single.new(proc {}), graceful_shutdown_timeout: 0
+        ),
         subscription: subscription2
       )
     end
@@ -339,7 +353,9 @@ RSpec.describe PgEventstore::SubscriptionFeederHandlers do
     let(:subscription_runner1) do
       PgEventstore::SubscriptionRunner.new(
         stats: PgEventstore::SubscriptionHandlerPerformance.new,
-        events_processor: PgEventstore::EventsProcessor.new(proc {}, graceful_shutdown_timeout: 0),
+        events_processor: PgEventstore::EventsProcessor.new(
+          consumer: PgEventstore::EventsProcessorConsumer::Single.new(proc {}), graceful_shutdown_timeout: 0
+        ),
         subscription: SubscriptionsHelper.create_with_connection(
           set: 'Foo', name: 'Bar', locked_by: subscriptions_set_lifecycle.persisted_subscriptions_set.id
         )
@@ -348,7 +364,9 @@ RSpec.describe PgEventstore::SubscriptionFeederHandlers do
     let(:subscription_runner2) do
       PgEventstore::SubscriptionRunner.new(
         stats: PgEventstore::SubscriptionHandlerPerformance.new,
-        events_processor: PgEventstore::EventsProcessor.new(proc {}, graceful_shutdown_timeout: 0),
+        events_processor: PgEventstore::EventsProcessor.new(
+          consumer: PgEventstore::EventsProcessorConsumer::Single.new(proc {}), graceful_shutdown_timeout: 0
+        ),
         subscription: SubscriptionsHelper.create_with_connection(
           set: 'Foo', name: 'Baz', locked_by: subscriptions_set_lifecycle.persisted_subscriptions_set.id
         )

--- a/spec/pg_eventstore/subscriptions/command_handlers/subscription_runners_commands_spec.rb
+++ b/spec/pg_eventstore/subscriptions/command_handlers/subscription_runners_commands_spec.rb
@@ -8,14 +8,18 @@ RSpec.describe PgEventstore::CommandHandlers::SubscriptionRunnersCommands do
   let(:runner1) do
     PgEventstore::SubscriptionRunner.new(
       stats: PgEventstore::SubscriptionHandlerPerformance.new,
-      events_processor: PgEventstore::EventsProcessor.new(proc {}, graceful_shutdown_timeout: 5),
+      events_processor: PgEventstore::EventsProcessor.new(
+        consumer: PgEventstore::EventsProcessorConsumer::Single.new(proc {}), graceful_shutdown_timeout: 5
+      ),
       subscription: SubscriptionsHelper.create_with_connection(name: 'Subscr1')
     )
   end
   let(:runner2) do
     PgEventstore::SubscriptionRunner.new(
       stats: PgEventstore::SubscriptionHandlerPerformance.new,
-      events_processor: PgEventstore::EventsProcessor.new(proc {}, graceful_shutdown_timeout: 5),
+      events_processor: PgEventstore::EventsProcessor.new(
+        consumer: PgEventstore::EventsProcessorConsumer::Single.new(proc {}), graceful_shutdown_timeout: 5
+      ),
       subscription: SubscriptionsHelper.create_with_connection(name: 'Subscr2')
     )
   end

--- a/spec/pg_eventstore/subscriptions/commands_handler_spec.rb
+++ b/spec/pg_eventstore/subscriptions/commands_handler_spec.rb
@@ -20,10 +20,11 @@ RSpec.describe PgEventstore::CommandsHandler do
     PgEventstore::SubscriptionsLifecycle.new(config_name, subscriptions_set_lifecycle)
   end
   let(:runners) { [runner] }
+  let(:consumer) { PgEventstore::EventsProcessorConsumer::Single.new(proc {}) }
   let(:runner) do
     PgEventstore::SubscriptionRunner.new(
       stats: PgEventstore::SubscriptionHandlerPerformance.new,
-      events_processor: PgEventstore::EventsProcessor.new(proc {}, graceful_shutdown_timeout: 5),
+      events_processor: PgEventstore::EventsProcessor.new(consumer:, graceful_shutdown_timeout: 5),
       subscription: SubscriptionsHelper.create_with_connection
     )
   end

--- a/spec/pg_eventstore/subscriptions/events_processor_consumer/multiple_spec.rb
+++ b/spec/pg_eventstore/subscriptions/events_processor_consumer/multiple_spec.rb
@@ -99,13 +99,6 @@ RSpec.describe PgEventstore::EventsProcessorConsumer::Multiple do
           end
         }.to change { Time.now }.by(be_between(0, 0.01))
       end
-      it 'does not process any event' do
-        begin
-          subject
-        rescue PgEventstore::WrappedException
-        end
-        expect(raw_events_handler).not_to have_received(:call)
-      end
       it 'runs only :before :process callbacks' do
         begin
           subject

--- a/spec/pg_eventstore/subscriptions/events_processor_consumer/multiple_spec.rb
+++ b/spec/pg_eventstore/subscriptions/events_processor_consumer/multiple_spec.rb
@@ -1,0 +1,145 @@
+# frozen_string_literal: true
+
+RSpec.describe PgEventstore::EventsProcessorConsumer::Multiple do
+  let(:instance) { described_class.new(handler) }
+  let(:handler) { proc { |raw_events| raw_events_handler.call(raw_events) } }
+  let(:raw_events_handler) { double('RawEventsHandler') }
+
+  before do
+    allow(raw_events_handler).to receive(:call)
+  end
+
+  it 'implements EventsProcessorConsumer' do
+    expect(instance).to be_a(PgEventstore::EventsProcessorConsumer)
+  end
+
+  describe '#call' do
+    subject { instance.call(callbacks, raw_events, raw_events_cond) }
+
+    let(:callbacks) { PgEventstore::Callbacks.new }
+    let(:raw_events) { PgEventstore::SynchronizedArray.new }
+    let(:raw_events_cond) { raw_events.new_cond }
+    let(:on_process_cbx) do
+      proc do |action, global_position|
+        position_handler_before.call(global_position)
+        action.call
+        position_handler_after.call(global_position)
+      end
+    end
+    let(:position_handler_before) { double('PositionHandlerBefore') }
+    let(:position_handler_after) { double('PositionHandlerAfter') }
+
+    before do
+      callbacks.define_callback(:process, :around, on_process_cbx)
+      allow(position_handler_before).to receive(:call)
+      allow(position_handler_after).to receive(:call)
+    end
+
+    context 'when no events are given' do
+      it 'sleeps for .5 seconds' do
+        expect { subject }.to change { Time.now }.by(be_between(0.5, 0.51))
+      end
+      it 'does not run :process callbacks' do
+        subject
+        aggregate_failures do
+          expect(position_handler_before).not_to have_received(:call)
+          expect(position_handler_after).not_to have_received(:call)
+        end
+      end
+      it 'does not process any event' do
+        subject
+        expect(raw_events_handler).not_to have_received(:call)
+      end
+    end
+
+    context 'when there are some events' do
+      let(:raw_events) { PgEventstore::SynchronizedArray.new([raw_event1, raw_event2]) }
+      let(:raw_event1) { { 'global_position' => 123 } }
+      let(:raw_event2) { { 'global_position' => 125 } }
+
+      it 'does not sleep' do
+        expect { subject }.to change { Time.now }.by(be_between(0, 0.01))
+      end
+      it 'runs :process callbacks for the last event' do
+        subject
+        expect(position_handler_after).to have_received(:call).with(raw_event2['global_position'])
+      end
+      it 'processes events' do
+        subject
+        expect(raw_events_handler).to have_received(:call).with([raw_event1, raw_event2])
+      end
+      it 'removes processed events from the list' do
+        expect { subject }.to change { raw_events }.to([])
+      end
+    end
+
+    context 'when handler raises an error' do
+      let(:raw_events) { PgEventstore::SynchronizedArray.new([raw_event1, raw_event2]) }
+      let(:raw_event1) { { 'global_position' => 123 } }
+      let(:raw_event2) { { 'global_position' => 125 } }
+
+      let(:handler) { proc { raise error_class, 'Oops!' } }
+      let(:error_class) { Class.new(StandardError) }
+
+      it 'does not sleep' do
+        expect {
+          begin
+            subject
+          rescue PgEventstore::WrappedException
+          end
+        }.to change { Time.now }.by(be_between(0, 0.01))
+      end
+      it 'does not process any event' do
+        begin
+          subject
+        rescue PgEventstore::WrappedException
+        end
+        expect(raw_events_handler).not_to have_received(:call)
+      end
+      it 'runs only :before :process callbacks' do
+        begin
+          subject
+        rescue PgEventstore::WrappedException
+        end
+        expect(position_handler_before).to have_received(:call).with(raw_event2['global_position'])
+      end
+      it 'does not remove events from the list' do
+        expect {
+          begin
+            subject
+          rescue PgEventstore::WrappedException
+          end
+        }.not_to change { raw_events }
+      end
+      # rubocop:disable RSpec/MultipleExpectations
+      it 'raises the error' do
+        expect { subject }.to raise_error(PgEventstore::WrappedException) do |error|
+          aggregate_failures do
+            expect(error.original_exception).to be_a(error_class)
+            expect(error.original_exception.message).to eq('Oops!')
+            expect(error.extra).to eq(global_positions: [raw_event1['global_position'], raw_event2['global_position']])
+          end
+        end
+      end
+      # rubocop:enable RSpec/MultipleExpectations
+
+      context 'when event which caused an exception is a link event' do
+        let(:raw_event1) { { 'global_position' => 123, 'link' => { 'global_position' => 321 } } }
+
+        # rubocop:disable RSpec/MultipleExpectations
+        it 'raises the error with correct global positions' do
+          expect { subject }.to raise_error(PgEventstore::WrappedException) do |error|
+            aggregate_failures do
+              expect(error.original_exception).to be_a(error_class)
+              expect(error.original_exception.message).to eq('Oops!')
+              expect(error.extra).to(
+                eq(global_positions: [raw_event1['link']['global_position'], raw_event2['global_position']])
+              )
+            end
+          end
+        end
+        # rubocop:enable RSpec/MultipleExpectations
+      end
+    end
+  end
+end

--- a/spec/pg_eventstore/subscriptions/events_processor_consumer/multiple_spec.rb
+++ b/spec/pg_eventstore/subscriptions/events_processor_consumer/multiple_spec.rb
@@ -62,7 +62,17 @@ RSpec.describe PgEventstore::EventsProcessorConsumer::Multiple do
       end
       it 'runs :process callbacks for the last event' do
         subject
-        expect(position_handler_after).to have_received(:call).with(raw_event2['global_position'])
+        aggregate_failures do
+          expect(position_handler_before).to have_received(:call).with(raw_event2['global_position'])
+          expect(position_handler_after).to have_received(:call).with(raw_event2['global_position'])
+        end
+      end
+      it 'does not run :process callbacks for first event' do
+        subject
+        aggregate_failures do
+          expect(position_handler_before).not_to have_received(:call).with(raw_event1['global_position'])
+          expect(position_handler_after).not_to have_received(:call).with(raw_event1['global_position'])
+        end
       end
       it 'processes events' do
         subject
@@ -101,7 +111,10 @@ RSpec.describe PgEventstore::EventsProcessorConsumer::Multiple do
           subject
         rescue PgEventstore::WrappedException
         end
-        expect(position_handler_before).to have_received(:call).with(raw_event2['global_position'])
+        aggregate_failures do
+          expect(position_handler_before).to have_received(:call).with(raw_event2['global_position'])
+          expect(position_handler_after).not_to have_received(:call)
+        end
       end
       it 'does not remove events from the list' do
         expect {

--- a/spec/pg_eventstore/subscriptions/events_processor_consumer/single_spec.rb
+++ b/spec/pg_eventstore/subscriptions/events_processor_consumer/single_spec.rb
@@ -103,13 +103,6 @@ RSpec.describe PgEventstore::EventsProcessorConsumer::Single do
           end
         }.to change { Time.now }.by(be_between(0, 0.01))
       end
-      it 'does not process any event' do
-        begin
-          subject
-        rescue PgEventstore::WrappedException
-        end
-        expect(raw_event_handler).not_to have_received(:call)
-      end
       it 'runs only :before :process callbacks' do
         begin
           subject

--- a/spec/pg_eventstore/subscriptions/events_processor_consumer/single_spec.rb
+++ b/spec/pg_eventstore/subscriptions/events_processor_consumer/single_spec.rb
@@ -1,0 +1,160 @@
+# frozen_string_literal: true
+
+RSpec.describe PgEventstore::EventsProcessorConsumer::Single do
+  let(:instance) { described_class.new(handler) }
+  let(:handler) { proc { |raw_event| raw_event_handler.call(raw_event) } }
+  let(:raw_event_handler) { double('RawEventHandler') }
+
+  before do
+    allow(raw_event_handler).to receive(:call)
+  end
+
+  it 'implements EventsProcessorConsumer' do
+    expect(instance).to be_a(PgEventstore::EventsProcessorConsumer)
+  end
+
+  describe '#call' do
+    subject { instance.call(callbacks, raw_events, raw_events_cond) }
+
+    let(:callbacks) { PgEventstore::Callbacks.new }
+    let(:raw_events) { PgEventstore::SynchronizedArray.new }
+    let(:raw_events_cond) { raw_events.new_cond }
+    let(:on_process_cbx) do
+      proc do |action, global_position|
+        position_handler_before.call(global_position)
+        action.call
+        position_handler_after.call(global_position)
+      end
+    end
+    let(:position_handler_before) { double('PositionHandlerBefore') }
+    let(:position_handler_after) { double('PositionHandlerAfter') }
+
+    before do
+      callbacks.define_callback(:process, :around, on_process_cbx)
+      allow(position_handler_before).to receive(:call)
+      allow(position_handler_after).to receive(:call)
+    end
+
+    context 'when no events are given' do
+      it 'sleeps for .5 seconds' do
+        expect { subject }.to change { Time.now }.by(be_between(0.5, 0.51))
+      end
+      it 'does not run :process callbacks' do
+        subject
+        aggregate_failures do
+          expect(position_handler_before).not_to have_received(:call)
+          expect(position_handler_after).not_to have_received(:call)
+        end
+      end
+      it 'does not process any event' do
+        subject
+        expect(raw_event_handler).not_to have_received(:call)
+      end
+    end
+
+    context 'when there are some events' do
+      let(:raw_events) { PgEventstore::SynchronizedArray.new([raw_event1, raw_event2]) }
+      let(:raw_event1) { { 'global_position' => 123 } }
+      let(:raw_event2) { { 'global_position' => 125 } }
+
+      it 'does not sleep' do
+        expect { subject }.to change { Time.now }.by(be_between(0, 0.01))
+      end
+      it 'runs :process callbacks for first event' do
+        subject
+        aggregate_failures do
+          expect(position_handler_before).to have_received(:call).with(raw_event1['global_position'])
+          expect(position_handler_after).to have_received(:call).with(raw_event1['global_position'])
+        end
+      end
+      it 'does not run :process callbacks for second event' do
+        subject
+        aggregate_failures do
+          expect(position_handler_before).not_to have_received(:call).with(raw_event2['global_position'])
+          expect(position_handler_after).not_to have_received(:call).with(raw_event2['global_position'])
+        end
+      end
+      it 'processes first event' do
+        subject
+        expect(raw_event_handler).to have_received(:call).with(raw_event1)
+      end
+      it 'does not process second event' do
+        subject
+        expect(raw_event_handler).not_to have_received(:call).with(raw_event2)
+      end
+      it 'removes processed event from the list' do
+        expect { subject }.to change { raw_events }.to([raw_event2])
+      end
+    end
+
+    context 'when handler raises an error' do
+      let(:raw_events) { PgEventstore::SynchronizedArray.new([raw_event1, raw_event2]) }
+      let(:raw_event1) { { 'global_position' => 123 } }
+      let(:raw_event2) { { 'global_position' => 125 } }
+
+      let(:handler) { proc { raise error_class, 'Oops!' } }
+      let(:error_class) { Class.new(StandardError) }
+
+      it 'does not sleep' do
+        expect {
+          begin
+            subject
+          rescue PgEventstore::WrappedException
+          end
+        }.to change { Time.now }.by(be_between(0, 0.01))
+      end
+      it 'does not process any event' do
+        begin
+          subject
+        rescue PgEventstore::WrappedException
+        end
+        expect(raw_event_handler).not_to have_received(:call)
+      end
+      it 'runs only :before :process callbacks' do
+        begin
+          subject
+        rescue PgEventstore::WrappedException
+        end
+        aggregate_failures do
+          expect(position_handler_before).to have_received(:call).with(raw_event1['global_position'])
+          expect(position_handler_after).not_to have_received(:call)
+        end
+      end
+      it 'does not remove first event from the list' do
+        expect {
+          begin
+            subject
+          rescue PgEventstore::WrappedException
+          end
+        }.not_to change { raw_events }
+      end
+      # rubocop:disable RSpec/MultipleExpectations
+      it 'raises the error' do
+        expect { subject }.to raise_error(PgEventstore::WrappedException) do |error|
+          aggregate_failures do
+            expect(error.original_exception).to be_a(error_class)
+            expect(error.original_exception.message).to eq('Oops!')
+            expect(error.extra).to eq(global_position: raw_event1['global_position'])
+          end
+        end
+      end
+      # rubocop:enable RSpec/MultipleExpectations
+
+      context 'when event which caused an exception is a link event' do
+        let(:raw_event1) { { 'global_position' => 123, 'link' => { 'global_position' => 321 } } }
+
+        # rubocop:disable RSpec/MultipleExpectations
+        it 'raises the error with correct global position' do
+          expect { subject }.to raise_error(PgEventstore::WrappedException) do |error|
+            aggregate_failures do
+              expect(error.original_exception).to be_a(error_class)
+              expect(error.original_exception.message).to eq('Oops!')
+              expect(error.extra).to eq(global_position: raw_event1['link']['global_position'])
+            end
+          end
+        end
+        # rubocop:enable RSpec/MultipleExpectations
+      end
+    end
+  end
+end

--- a/spec/pg_eventstore/subscriptions/events_processor_spec.rb
+++ b/spec/pg_eventstore/subscriptions/events_processor_spec.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 RSpec.describe PgEventstore::EventsProcessor do
-  let(:instance) { described_class.new(handler, graceful_shutdown_timeout:) }
+  let(:instance) { described_class.new(consumer:, graceful_shutdown_timeout:) }
   let(:handler) { proc { |raw_event| processed_events.push(raw_event['id']) } }
+  let(:consumer) { PgEventstore::EventsProcessorConsumer::Single.new(handler) }
   let(:graceful_shutdown_timeout) { 5 }
   let(:processed_events) { [] }
 

--- a/spec/pg_eventstore/subscriptions/subscription_feeder_spec.rb
+++ b/spec/pg_eventstore/subscriptions/subscription_feeder_spec.rb
@@ -28,14 +28,18 @@ RSpec.describe PgEventstore::SubscriptionFeeder do
     let(:subscription_runner1) do
       PgEventstore::SubscriptionRunner.new(
         stats: PgEventstore::SubscriptionHandlerPerformance.new,
-        events_processor: PgEventstore::EventsProcessor.new(proc {}, graceful_shutdown_timeout: 5),
+        events_processor: PgEventstore::EventsProcessor.new(
+          consumer: PgEventstore::EventsProcessorConsumer::Single.new(proc {}), graceful_shutdown_timeout: 5
+        ),
         subscription: SubscriptionsHelper.init_with_connection
       )
     end
     let(:subscription_runner2) do
       PgEventstore::SubscriptionRunner.new(
         stats: PgEventstore::SubscriptionHandlerPerformance.new,
-        events_processor: PgEventstore::EventsProcessor.new(proc {}, graceful_shutdown_timeout: 5),
+        events_processor: PgEventstore::EventsProcessor.new(
+          consumer: PgEventstore::EventsProcessorConsumer::Single.new(proc {}), graceful_shutdown_timeout: 5
+        ),
         subscription: SubscriptionsHelper.init_with_connection(name: 'Bar')
       )
     end
@@ -138,14 +142,18 @@ RSpec.describe PgEventstore::SubscriptionFeeder do
     let(:subscription_runner1) do
       PgEventstore::SubscriptionRunner.new(
         stats: PgEventstore::SubscriptionHandlerPerformance.new,
-        events_processor: PgEventstore::EventsProcessor.new(proc {}, graceful_shutdown_timeout: 5),
+        events_processor: PgEventstore::EventsProcessor.new(
+          consumer: PgEventstore::EventsProcessorConsumer::Single.new(proc {}), graceful_shutdown_timeout: 5
+        ),
         subscription: SubscriptionsHelper.init_with_connection
       )
     end
     let(:subscription_runner2) do
       PgEventstore::SubscriptionRunner.new(
         stats: PgEventstore::SubscriptionHandlerPerformance.new,
-        events_processor: PgEventstore::EventsProcessor.new(proc {}, graceful_shutdown_timeout: 5),
+        events_processor: PgEventstore::EventsProcessor.new(
+          consumer: PgEventstore::EventsProcessorConsumer::Single.new(proc {}), graceful_shutdown_timeout: 5
+        ),
         subscription: SubscriptionsHelper.init_with_connection(name: 'Bar')
       )
     end
@@ -303,14 +311,18 @@ RSpec.describe PgEventstore::SubscriptionFeeder do
     let(:subscription_runner1) do
       PgEventstore::SubscriptionRunner.new(
         stats: PgEventstore::SubscriptionHandlerPerformance.new,
-        events_processor: PgEventstore::EventsProcessor.new(proc {}, graceful_shutdown_timeout: 5),
+        events_processor: PgEventstore::EventsProcessor.new(
+          consumer: PgEventstore::EventsProcessorConsumer::Single.new(proc {}), graceful_shutdown_timeout: 5
+        ),
         subscription: subscription1
       )
     end
     let(:subscription_runner2) do
       PgEventstore::SubscriptionRunner.new(
         stats: PgEventstore::SubscriptionHandlerPerformance.new,
-        events_processor: PgEventstore::EventsProcessor.new(proc {}, graceful_shutdown_timeout: 5),
+        events_processor: PgEventstore::EventsProcessor.new(
+          consumer: PgEventstore::EventsProcessorConsumer::Single.new(proc {}), graceful_shutdown_timeout: 5
+        ),
         subscription: subscription2
       )
     end
@@ -397,7 +409,8 @@ RSpec.describe PgEventstore::SubscriptionFeeder do
       PgEventstore::SubscriptionRunner.new(
         stats: PgEventstore::SubscriptionHandlerPerformance.new,
         events_processor: PgEventstore::EventsProcessor.new(
-          proc { |event| processed_events.push(event) }, graceful_shutdown_timeout: 5
+          consumer: PgEventstore::EventsProcessorConsumer::Single.new(proc { |event| processed_events.push(event) }),
+          graceful_shutdown_timeout: 5
         ),
         subscription: SubscriptionsHelper.init_with_connection(set: set_name)
       )
@@ -509,7 +522,10 @@ RSpec.describe PgEventstore::SubscriptionFeeder do
       PgEventstore::SubscriptionRunner.new(
         stats: PgEventstore::SubscriptionHandlerPerformance.new,
         events_processor: PgEventstore::EventsProcessor.new(
-          proc { |raw_event| processed_events1.push(raw_event) }, graceful_shutdown_timeout: 5
+          consumer: PgEventstore::EventsProcessorConsumer::Single.new(
+            proc { |raw_event| processed_events1.push(raw_event) }
+          ),
+          graceful_shutdown_timeout: 5
         ),
         subscription: SubscriptionsHelper.create_with_connection(options: { filter: { event_types: ['Bar'] } })
       )
@@ -518,7 +534,10 @@ RSpec.describe PgEventstore::SubscriptionFeeder do
       PgEventstore::SubscriptionRunner.new(
         stats: PgEventstore::SubscriptionHandlerPerformance.new,
         events_processor: PgEventstore::EventsProcessor.new(
-          proc { |raw_event| processed_events2.push(raw_event) }, graceful_shutdown_timeout: 5
+          consumer: PgEventstore::EventsProcessorConsumer::Single.new(
+            proc { |raw_event| processed_events2.push(raw_event) }
+          ),
+          graceful_shutdown_timeout: 5
         ),
         subscription: SubscriptionsHelper.create_with_connection(
           name: 'sub2', options: { filter: { event_types: ['Baz'] } }
@@ -581,14 +600,20 @@ RSpec.describe PgEventstore::SubscriptionFeeder do
     let(:subscription_runner1) do
       PgEventstore::SubscriptionRunner.new(
         stats: PgEventstore::SubscriptionHandlerPerformance.new,
-        events_processor: PgEventstore::EventsProcessor.new(proc {}, graceful_shutdown_timeout: 5),
+        events_processor: PgEventstore::EventsProcessor.new(
+          consumer: PgEventstore::EventsProcessorConsumer::Single.new(proc {}),
+          graceful_shutdown_timeout: 5
+        ),
         subscription: SubscriptionsHelper.create_with_connection(name: 'Foo')
       )
     end
     let(:subscription_runner2) do
       PgEventstore::SubscriptionRunner.new(
         stats: PgEventstore::SubscriptionHandlerPerformance.new,
-        events_processor: PgEventstore::EventsProcessor.new(proc {}, graceful_shutdown_timeout: 5),
+        events_processor: PgEventstore::EventsProcessor.new(
+          consumer: PgEventstore::EventsProcessorConsumer::Single.new(proc {}),
+          graceful_shutdown_timeout: 5
+        ),
         subscription: SubscriptionsHelper.create_with_connection(name: 'Bar')
       )
     end
@@ -658,14 +683,18 @@ RSpec.describe PgEventstore::SubscriptionFeeder do
     let(:subscription_runner1) do
       PgEventstore::SubscriptionRunner.new(
         stats: PgEventstore::SubscriptionHandlerPerformance.new,
-        events_processor: PgEventstore::EventsProcessor.new(proc {}, graceful_shutdown_timeout: 5),
+        events_processor: PgEventstore::EventsProcessor.new(
+          consumer: PgEventstore::EventsProcessorConsumer::Single.new(proc {}), graceful_shutdown_timeout: 5
+        ),
         subscription: SubscriptionsHelper.create_with_connection(name: 'Foo')
       )
     end
     let(:subscription_runner2) do
       PgEventstore::SubscriptionRunner.new(
         stats: PgEventstore::SubscriptionHandlerPerformance.new,
-        events_processor: PgEventstore::EventsProcessor.new(proc {}, graceful_shutdown_timeout: 5),
+        events_processor: PgEventstore::EventsProcessor.new(
+          consumer: PgEventstore::EventsProcessorConsumer::Single.new(proc {}), graceful_shutdown_timeout: 5
+        ),
         subscription: SubscriptionsHelper.create_with_connection(name: 'Bar')
       )
     end

--- a/spec/pg_eventstore/subscriptions/subscription_runner_commands/reset_position_spec.rb
+++ b/spec/pg_eventstore/subscriptions/subscription_runner_commands/reset_position_spec.rb
@@ -51,7 +51,11 @@ RSpec.describe PgEventstore::SubscriptionRunnerCommands::ResetPosition do
 
     let(:position) { 123 }
     let(:stats) { PgEventstore::SubscriptionHandlerPerformance.new }
-    let(:events_processor) { PgEventstore::EventsProcessor.new(handler, graceful_shutdown_timeout: 5) }
+    let(:events_processor) do
+      PgEventstore::EventsProcessor.new(
+        consumer: PgEventstore::EventsProcessorConsumer::Single.new(handler), graceful_shutdown_timeout: 5
+      )
+    end
     let(:subscription) do
       SubscriptionsHelper.create_with_connection(last_chunk_greatest_position: 321, total_processed_events: 120)
     end

--- a/spec/pg_eventstore/subscriptions/subscription_runner_commands/restore_spec.rb
+++ b/spec/pg_eventstore/subscriptions/subscription_runner_commands/restore_spec.rb
@@ -30,7 +30,9 @@ RSpec.describe PgEventstore::SubscriptionRunnerCommands::Restore do
     let(:subscription_runner) do
       PgEventstore::SubscriptionRunner.new(
         stats: PgEventstore::SubscriptionHandlerPerformance.new,
-        events_processor: PgEventstore::EventsProcessor.new(handler, graceful_shutdown_timeout: 5),
+        events_processor: PgEventstore::EventsProcessor.new(
+          consumer: PgEventstore::EventsProcessorConsumer::Single.new(handler), graceful_shutdown_timeout: 5
+        ),
         subscription:
       )
     end

--- a/spec/pg_eventstore/subscriptions/subscription_runner_spec.rb
+++ b/spec/pg_eventstore/subscriptions/subscription_runner_spec.rb
@@ -10,7 +10,9 @@ RSpec.describe PgEventstore::SubscriptionRunner do
   end
   let(:stats) { PgEventstore::SubscriptionHandlerPerformance.new }
   let(:events_processor) do
-    PgEventstore::EventsProcessor.new(handler, graceful_shutdown_timeout: 5)
+    PgEventstore::EventsProcessor.new(
+      consumer: PgEventstore::EventsProcessorConsumer::Single.new(handler), graceful_shutdown_timeout: 5
+    )
   end
   let(:subscription) { SubscriptionsHelper.create_with_connection(name: 'Foo') }
   let(:handler) { proc {} }
@@ -343,7 +345,7 @@ RSpec.describe PgEventstore::SubscriptionRunner do
 
     let(:events_processor) do
       PgEventstore::EventsProcessor.new(
-        handler,
+        consumer: PgEventstore::EventsProcessorConsumer::Single.new(handler),
         graceful_shutdown_timeout: 0,
         recovery_strategies: [
           DummyErrorRecovery.new(recoverable_message: 'You rolled 1. Critical failure!', seconds_before_recovery: 0.1),

--- a/spec/pg_eventstore/subscriptions/subscription_runners_feeder_spec.rb
+++ b/spec/pg_eventstore/subscriptions/subscription_runners_feeder_spec.rb
@@ -10,14 +10,18 @@ RSpec.describe PgEventstore::SubscriptionRunnersFeeder do
     let(:runner1) do
       PgEventstore::SubscriptionRunner.new(
         stats: PgEventstore::SubscriptionHandlerPerformance.new,
-        events_processor: PgEventstore::EventsProcessor.new(proc {}, graceful_shutdown_timeout: 5),
+        events_processor: PgEventstore::EventsProcessor.new(
+          consumer: PgEventstore::EventsProcessorConsumer::Single.new(proc {}), graceful_shutdown_timeout: 5
+        ),
         subscription: SubscriptionsHelper.create_with_connection(name: 'Foo', options: options1)
       )
     end
     let(:runner2) do
       PgEventstore::SubscriptionRunner.new(
         stats: PgEventstore::SubscriptionHandlerPerformance.new,
-        events_processor: PgEventstore::EventsProcessor.new(proc {}, graceful_shutdown_timeout: 5),
+        events_processor: PgEventstore::EventsProcessor.new(
+          consumer: PgEventstore::EventsProcessorConsumer::Single.new(proc {}), graceful_shutdown_timeout: 5
+        ),
         subscription: SubscriptionsHelper.create_with_connection(name: 'Bar', options: options2)
       )
     end

--- a/spec/pg_eventstore/subscriptions/subscriptions_lifecycle_spec.rb
+++ b/spec/pg_eventstore/subscriptions/subscriptions_lifecycle_spec.rb
@@ -16,7 +16,9 @@ RSpec.describe PgEventstore::SubscriptionsLifecycle do
     let(:subscription_runner1) do
       PgEventstore::SubscriptionRunner.new(
         stats: PgEventstore::SubscriptionHandlerPerformance.new,
-        events_processor: PgEventstore::EventsProcessor.new(proc {}, graceful_shutdown_timeout: 0),
+        events_processor: PgEventstore::EventsProcessor.new(
+          consumer: PgEventstore::EventsProcessorConsumer::Single.new(proc {}), graceful_shutdown_timeout: 0
+        ),
         subscription: subscription1
       )
     end
@@ -24,7 +26,9 @@ RSpec.describe PgEventstore::SubscriptionsLifecycle do
     let(:subscription_runner2) do
       PgEventstore::SubscriptionRunner.new(
         stats: PgEventstore::SubscriptionHandlerPerformance.new,
-        events_processor: PgEventstore::EventsProcessor.new(proc {}, graceful_shutdown_timeout: 0),
+        events_processor: PgEventstore::EventsProcessor.new(
+          consumer: PgEventstore::EventsProcessorConsumer::Single.new(proc {}), graceful_shutdown_timeout: 0
+        ),
         subscription: subscription2
       )
     end
@@ -109,7 +113,9 @@ RSpec.describe PgEventstore::SubscriptionsLifecycle do
     let(:subscription_runner1) do
       PgEventstore::SubscriptionRunner.new(
         stats: PgEventstore::SubscriptionHandlerPerformance.new,
-        events_processor: PgEventstore::EventsProcessor.new(proc {}, graceful_shutdown_timeout: 0),
+        events_processor: PgEventstore::EventsProcessor.new(
+          consumer: PgEventstore::EventsProcessorConsumer::Single.new(proc {}), graceful_shutdown_timeout: 0
+        ),
         subscription: subscription1
       )
     end
@@ -121,7 +127,9 @@ RSpec.describe PgEventstore::SubscriptionsLifecycle do
     let(:subscription_runner2) do
       PgEventstore::SubscriptionRunner.new(
         stats: PgEventstore::SubscriptionHandlerPerformance.new,
-        events_processor: PgEventstore::EventsProcessor.new(proc {}, graceful_shutdown_timeout: 0),
+        events_processor: PgEventstore::EventsProcessor.new(
+          consumer: PgEventstore::EventsProcessorConsumer::Single.new(proc {}), graceful_shutdown_timeout: 0
+        ),
         subscription: subscription2
       )
     end
@@ -213,7 +221,9 @@ RSpec.describe PgEventstore::SubscriptionsLifecycle do
     let(:subscription_runner1) do
       PgEventstore::SubscriptionRunner.new(
         stats: PgEventstore::SubscriptionHandlerPerformance.new,
-        events_processor: PgEventstore::EventsProcessor.new(proc {}, graceful_shutdown_timeout: 0),
+        events_processor: PgEventstore::EventsProcessor.new(
+          consumer: PgEventstore::EventsProcessorConsumer::Single.new(proc {}), graceful_shutdown_timeout: 0
+        ),
         subscription: subscription1
       )
     end
@@ -221,7 +231,9 @@ RSpec.describe PgEventstore::SubscriptionsLifecycle do
     let(:subscription_runner2) do
       PgEventstore::SubscriptionRunner.new(
         stats: PgEventstore::SubscriptionHandlerPerformance.new,
-        events_processor: PgEventstore::EventsProcessor.new(proc {}, graceful_shutdown_timeout: 0),
+        events_processor: PgEventstore::EventsProcessor.new(
+          consumer: PgEventstore::EventsProcessorConsumer::Single.new(proc {}), graceful_shutdown_timeout: 0
+        ),
         subscription: subscription2
       )
     end

--- a/spec/subscriptions_integration_spec.rb
+++ b/spec/subscriptions_integration_spec.rb
@@ -768,4 +768,36 @@ RSpec.describe 'Subscriptions integration' do
     end
     # rubocop:enable Style/ZeroLengthPredicate
   end
+
+  describe 'processing events in batches' do
+    subject { manager.start }
+
+    let(:manager) { PgEventstore.subscriptions_manager(subscription_set: set_name) }
+    let(:set_name) { 'Microservice 1 Subscriptions' }
+
+    let(:handler) { proc { |event| processed_events.push(event) } }
+    let(:processed_events) { [] }
+
+    let(:stream) { PgEventstore::Stream.new(context: 'FooCtx', stream_name: 'Foo', stream_id: 'bar') }
+    let(:event1) { PgEventstore::Event.new(data: { foo: :bar }, type: 'Foo') }
+    let(:event2) { PgEventstore::Event.new(data: { bar: :baz }, type: 'Bar') }
+
+    before do
+      PgEventstore.client.append_to_stream(stream, [event1, event2])
+      PgEventstore.configure do |c|
+        c.subscription_pull_interval = 0.2
+      end
+      manager.subscribe('Subscription 1', handler:, in_batches: true)
+    end
+
+    after do
+      manager.stop
+    end
+
+    it 'processes events in batches' do
+      expect { subject }.to change {
+        dv(processed_events).deferred_wait(timeout: 0.5) { _1.size == 2 }
+      }.to([PgEventstore.client.read(stream)])
+    end
+  end
 end


### PR DESCRIPTION
New feature: allow subscription to process events in batches. You can now provide `in_batches: true` to `#subscribe` to yield an array of events(currently only one event is yielded)