### PR TITLE
ci: publish gem via RubyGems trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -38,20 +38,26 @@ jobs:
     needs: build
     name: Publish to RubyGems
     runs-on: ubuntu-latest
+    # OIDC trusted publishing: id-token to mint the short-lived RubyGems token,
+    # contents:read for the checkout. No long-lived API key secret required.
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: 3.4
-      - name: Publish
+      # Exchanges GitHub's OIDC token for a short-lived RubyGems credential.
+      # Requires a matching Trusted Publisher configured on rubygems.org
+      # (repo yousty/pg_eventstore, workflow file gem-push.yml).
+      - name: Configure RubyGems trusted-publishing credentials
+        uses: rubygems/configure-rubygems-credentials@v2.1.0
+      - name: Build and push gem
         run: |
-          mkdir -p $HOME/.gem
-          touch $HOME/.gem/credentials
-          chmod 0600 $HOME/.gem/credentials
-          printf -- "---\n:rubygems_api_key: ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
           gem build *.gemspec
           gem push *.gem
-        env:
-          GEM_HOST_API_KEY: ${{secrets.RUBYGEMS_AUTH_TOKEN}}


### PR DESCRIPTION
## What
Switches the gem publish step in `.github/workflows/gem-push.yml` from a long-lived API key to **RubyGems Trusted Publishing (OIDC)**.

- The `push` job now requests `permissions: { id-token: write, contents: read }` and uses `rubygems/configure-rubygems-credentials@v2.1.0` to mint a short-lived RubyGems credential at publish time.
- `gem build` / `gem push` are unchanged; the `secrets.RUBYGEMS_AUTH_TOKEN` API key is **no longer used**.
- Release trigger (push to the `release` branch) and the test matrix job are unchanged.
- Also bumped the publish job's `actions/checkout` to `v5` (+ `persist-credentials: false`).

## Required on RubyGems.org (one-time, by a gem owner)
A matching **Trusted Publisher** must exist for this gem (rubygems.org/gems/pg_eventstore → Trusted publishers → Create):
- Type: **GitHub Actions**
- Repository owner / name: **yousty / pg_eventstore**
- Workflow filename: **gem-push.yml**
- Environment: *(blank)* — matches this workflow (no `environment:` set)

Once that's in place, publishing works keylessly. After the next successful release, the `RUBYGEMS_AUTH_TOKEN` repo secret can be deleted.

## Notes
- Kept the existing branch-based release flow (didn't switch to the guide's tag-triggered `rubygems/release-gem@v1`) to avoid changing how the team ships. If you'd prefer the tag-based flow and/or a required-approval `release` environment later, easy follow-up (set the env on both the workflow and the trusted-publisher config).

🤖 Generated with [Claude Code](https://claude.com/claude-code)