### PR TITLE
ci: gate gem publish behind the Release environment

### DIFF
--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -38,6 +38,10 @@ jobs:
     needs: build
     name: Publish to RubyGems
     runs-on: ubuntu-latest
+    # Gated by the "Release" environment (required reviewers) so publishing needs
+    # explicit approval — commit access alone is not enough. The name must match the
+    # GitHub environment AND the rubygems.org trusted-publisher "Environment" field.
+    environment: Release
     # OIDC trusted publishing: id-token to mint the short-lived RubyGems token,
     # contents:read for the checkout. No long-lived API key secret required.
     permissions:


### PR DESCRIPTION
Follow-up to #22. Adds `environment: Release` to the publish job so releasing requires **explicit approval** from the environment's required reviewers — commit access to the repo is no longer enough to publish a gem.

## Must be in sync (case-sensitive `Release`)
- GitHub environment: **Release** (created, with required reviewers) ✅
- Workflow `environment: Release` (this PR) ✅
- **rubygems.org trusted publisher → Environment field: `Release`** ⚠️ currently blank — set it so the OIDC claim matches, otherwise publishing will be rejected.

## Recommended environment hardening (repo Settings → Environments → Release)
- Deployment branches: restrict to `release` (currently "No restriction").
- Enable "Prevent self-review" for a real two-person rule.
- Optionally uncheck "Allow administrators to bypass…".

After this, a push to `release` runs tests, then **pauses for reviewer approval** before the OIDC publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)