### PR TITLE
Allow middlewares to opt out of deserializing appended events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ db/postgresql/
 *.tar.gz
 .codex/
 .agents/
+
+# Internal agent tooling / work tracking
+.development/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 ## [Unreleased]
 
+- New feature: per-middleware opt-out of the deserialization of appended events. A middleware can now implement
+  `#deserialize_on_append?` and return `false` from it to skip its `#deserialize` on the event(s) echoed back by
+  `#append_to_stream`/`#link_to`. Reading events and subscriptions are not affected. This replaces the
+  "define a second middleware class without `#deserialize` and select it per call" workaround which was suggested in
+  the v3.0.0 notes below. Example:
+
+```ruby
+class MyMiddleware
+  include PgEventstore::Middleware
+
+  # Skip the (expensive) #deserialize of the events returned by #append_to_stream/#link_to
+  def deserialize_on_append?
+    false
+  end
+
+  def serialize(event)
+    # do something with event before persisting it
+  end
+
+  def deserialize(event)
+    # do something with event after reading it from db
+  end
+end
+```
+
+  The default is `true`, thus there is no behavior change for existing middlewares. Middlewares which don't include
+  `PgEventstore::Middleware` and don't implement `#deserialize_on_append?` are treated as if it returned `true`.
+
 ## [3.0.0]
 
 - New feature: pg_eventstore replication

--- a/docs/AGENTS.fragment.md
+++ b/docs/AGENTS.fragment.md
@@ -664,6 +664,11 @@ Commands can retry, so both methods must be deterministic and retry-safe, and an
 Append, read, and subscription calls use all configured middleware by default; passing `middlewares: [:name]` selects
 only those entries. Links are the exception and default to none.
 
+`#deserialize` also runs on the event(s) returned by `append_to_stream`/`link_to`. A middleware whose `#deserialize` is
+expensive and irrelevant on the write path can opt out of that by implementing `deserialize_on_append?` and returning
+`false`; reads and subscriptions keep calling it. Do not opt out middlewares whose attributes are read from the
+returned event, such as `PgEventstore::Middleware::EventTracing`.
+
 To opt into causation/correlation tracing, register `PgEventstore::Middleware::EventTracing` and pass a persisted event
 as `caused_by:` when creating the next event. The middleware then assigns `causation_id`, propagates or creates
 `correlation_id`, and indexes the identifiers as feature markers.

--- a/docs/writing_middleware.md
+++ b/docs/writing_middleware.md
@@ -3,7 +3,9 @@
 Middlewares are objects that modify events before they are appended to a stream, or right after they are read from a
 stream. Middleware object must respond to `#serialize` and `#deserialize` methods. The `#serialize` method is called
 each time an event is going to be appended. The `#deserialize` method is called each time an event is read from a
-stream. There are two ways how you can define a middleware:
+stream, as well as on the event(s) returned by `#append_to_stream`/`#link_to` - see
+[Skipping deserialization of appended events](#skipping-deserialization-of-appended-events) if you want to opt out of
+the latter. There are two ways how you can define a middleware:
 
 - by defining your class and including `PgEventstore::Middleware` module in it. This way you can override only one of
   its methods, or both of them. Example:
@@ -132,6 +134,42 @@ stream = PgEventstore::Stream.new(context: 'ctx', stream_name: 'some-stream', st
 PgEventstore.client.read(stream).last
 # => #<DescriptionChangedEvent:0x0 @data={"description"=>"some description"}, ...>
 ```
+
+## Skipping deserialization of appended events
+
+`#append_to_stream` and `#link_to` return the persisted event(s), and those events are passed through the `#deserialize`
+method of each applied middleware. This is what allows middlewares like
+[event tracing](event_tracing.md) to restore their attributes on the returned event. If your `#deserialize`
+implementation is expensive - for example, it performs an HTTP request - and its result is not needed on the write path,
+you can opt the middleware out of it by implementing `#deserialize_on_append?`:
+
+```ruby
+class Encryptor
+  include PgEventstore::Middleware
+
+  # Events, returned by #append_to_stream/#link_to, won't be decrypted
+  def deserialize_on_append?
+    false
+  end
+
+  def serialize(event)
+    event.data.merge!(encrypt(event.data))
+  end
+
+  def deserialize(event)
+    event.data.merge!(decrypt(event.data))
+  end
+end
+```
+
+Remarks:
+
+- it only affects the events which are echoed back by `#append_to_stream` and `#link_to`. `#read`, `#read_paginated`,
+  `#read_grouped` and subscriptions are not affected, and neither is `#serialize`;
+- it is defined per middleware, and not per direction. Middlewares which must run on the appended event - like
+  `PgEventstore::Middleware::EventTracing` - simply keep the default;
+- middlewares which don't implement it - e.g. plain objects which only respond to `#serialize` and `#deserialize` -
+  behave as if it returned `true`. Including `PgEventstore::Middleware` gives you that default for free.
 
 ## Remarks
 

--- a/lib/pg_eventstore/client.rb
+++ b/lib/pg_eventstore/client.rb
@@ -31,10 +31,13 @@ module PgEventstore
     # @param middlewares [Array<Symbol>, nil] provide a list of middleware names to override a config's middlewares
     # @return [PgEventstore::Event, Array<PgEventstore::Event>] persisted event(s)
     # @raise [PgEventstore::WrongExpectedRevisionError]
+    # @see PgEventstore::Middleware#deserialize_on_append? to opt a middleware out of deserializing the returned
+    #   event(s)
     def append_to_stream(stream, events_or_event, options: {}, middlewares: nil)
       Utils.assert_node_role!(config, Config::NodeRole.writable)
       middlewares = self.middlewares(middlewares)
       event_modifier = Commands::EventModifiers::PrepareRegularEvent.new(EventSerializer.new(middlewares))
+      deserializer = event_deserializer(append_deserialize_middlewares(middlewares))
       queries = Queries.new(
         partitions: partition_queries,
         events: event_queries,
@@ -46,7 +49,7 @@ module PgEventstore
         index_filtering: index_filtering_queries
       )
       result = Commands::Append.new(queries).call(
-        stream, *events_or_event, event_modifier:, deserializer: event_deserializer(middlewares), options:
+        stream, *events_or_event, event_modifier:, deserializer:, options:
       )
       events_or_event.is_a?(Array) ? result : result.first
     end
@@ -224,12 +227,15 @@ module PgEventstore
     #   middlewares will be applied to the "link" event
     # @return [PgEventstore::Event, Array<PgEventstore::Event>] persisted event(s)
     # @raise [PgEventstore::WrongExpectedRevisionError]
+    # @see PgEventstore::Middleware#deserialize_on_append? to opt a middleware out of deserializing the returned
+    #   event(s)
     def link_to(stream, events_or_event, options: {}, middlewares: [])
       Utils.assert_node_role!(config, Config::NodeRole.writable)
       middlewares = self.middlewares(middlewares)
       event_modifier = Commands::EventModifiers::PrepareLinkEvent.new(
         partition_queries, EventSerializer.new(middlewares)
       )
+      deserializer = event_deserializer(append_deserialize_middlewares(middlewares))
       queries = Queries.new(
         partitions: partition_queries,
         events: event_queries,
@@ -241,7 +247,7 @@ module PgEventstore
         index_filtering: index_filtering_queries
       )
       result = Commands::LinkTo.new(queries).call(
-        stream, *events_or_event, event_modifier:, deserializer: event_deserializer(middlewares), options:
+        stream, *events_or_event, event_modifier:, deserializer:, options:
       )
       events_or_event.is_a?(Array) ? result : result.first
     end
@@ -261,6 +267,17 @@ module PgEventstore
       return config.middlewares.values unless middlewares
 
       config.middlewares.slice(*middlewares).values
+    end
+
+    # Filters out middlewares which opted out of deserializing the events echoed back by #append_to_stream/#link_to.
+    # Middlewares are not required to include PgEventstore::Middleware, so a middleware which does not implement
+    # #deserialize_on_append? is treated as if it returned +true+.
+    # @param middlewares [Array<PgEventstore::Middleware>]
+    # @return [Array<PgEventstore::Middleware>]
+    def append_deserialize_middlewares(middlewares)
+      middlewares.select do |middleware|
+        !middleware.respond_to?(:deserialize_on_append?) || middleware.deserialize_on_append?
+      end
     end
 
     # @return [PgEventstore::Connection]

--- a/lib/pg_eventstore/commands/append.rb
+++ b/lib/pg_eventstore/commands/append.rb
@@ -59,8 +59,8 @@ module PgEventstore
             end
           end
         end
-        # It is important to return events in the form they were persisted into the database instead passing them
-        # through the configured middlewares
+        # Persisted events are deserialized before they are returned. Middlewares which must not run on the append
+        # path are already filtered out of the given deserializer.
         deserializer.deserialize_many(raw_events)
       end
 

--- a/lib/pg_eventstore/middleware.rb
+++ b/lib/pg_eventstore/middleware.rb
@@ -11,5 +11,14 @@ module PgEventstore
     # @return [void]
     def deserialize(event)
     end
+
+    # Whether #deserialize should be applied to the events which are echoed back by
+    # PgEventstore::Client#append_to_stream and PgEventstore::Client#link_to. Override it and return +false+ to skip the
+    # deserialization of the appended events. Useful when #deserialize is expensive and its result is not needed on the
+    # write path. Reading events is not affected by this setting.
+    # @return [Boolean]
+    def deserialize_on_append?
+      true
+    end
   end
 end

--- a/sig/pg_eventstore/client.rbs
+++ b/sig/pg_eventstore/client.rbs
@@ -58,6 +58,8 @@ module PgEventstore
 
     def middlewares: (?::Array[::Symbol]? middlewares) -> ::Array[Middleware]
 
+    def append_deserialize_middlewares: (::Array[Middleware] middlewares) -> ::Array[Middleware]
+
     def connection: () -> Connection
   end
 end

--- a/sig/pg_eventstore/middleware.rbs
+++ b/sig/pg_eventstore/middleware.rbs
@@ -5,5 +5,7 @@ module PgEventstore
 
     # _@param_ `event`
     def deserialize: (PgEventstore::Event event) -> void
+
+    def deserialize_on_append?: () -> bool
   end
 end

--- a/spec/pg_eventstore/client_spec.rb
+++ b/spec/pg_eventstore/client_spec.rb
@@ -21,6 +21,29 @@ RSpec.describe PgEventstore::Client do
     end
   end
 
+  let(:read_only_middleware) do
+    Class.new(middleware) do
+      def deserialize_on_append?
+        false
+      end
+    end
+  end
+  let(:plain_object_middleware) do
+    Class.new do
+      def initialize(value)
+        @value = value
+      end
+
+      def serialize(event)
+        event.metadata[@value] = "secret-#{@value}"
+      end
+
+      def deserialize(event)
+        event.metadata[@value] = @value
+      end
+    end
+  end
+
   before do
     PgEventstore.configure do |config|
       config.middlewares = { foo: middleware.new('foo'), bar: middleware.new('bar'), baz: middleware.new('baz') }
@@ -145,6 +168,48 @@ RSpec.describe PgEventstore::Client do
             expect(subject.markers).to eq(['bar'])
             expect(subject.metadata).to include(PgEventstore::Event::MARKERS_METADATA_KEY => ['bar'])
           end
+        end
+      end
+    end
+
+    describe 'deserialization of the appended event' do
+      subject { instance.append_to_stream(stream, event) }
+
+      let(:stream) { PgEventstore::Stream.new(context: 'ctx', stream_name: 'foo', stream_id: 'bar') }
+      let(:event) { PgEventstore::Event.new(type: 'foo') }
+      let(:persisted_metadata) { instance.read(stream, middlewares: []).last.metadata }
+
+      context 'when a middleware opts out of the deserialization on append' do
+        before do
+          PgEventstore.configure do |config|
+            config.middlewares = { foo: middleware.new('foo'), bar: read_only_middleware.new('bar') }
+          end
+        end
+
+        it 'skips #deserialize of that middleware' do
+          expect(subject.metadata).to eq('foo' => 'foo', 'bar' => 'secret-bar')
+        end
+        it 'still applies #serialize of that middleware' do
+          subject
+          expect(persisted_metadata).to eq('foo' => 'secret-foo', 'bar' => 'secret-bar')
+        end
+        it 'still applies #deserialize of that middleware when reading the event' do
+          subject
+          expect(instance.read(stream).last.metadata).to eq('foo' => 'foo', 'bar' => 'bar')
+        end
+      end
+
+      # :rbs_skip - sig/pg_eventstore/config.rbs types middlewares as PgEventstore::Middleware, while a middleware is
+      # only required to respond to #serialize/#deserialize. See docs/writing_middleware.md.
+      context 'when a middleware does not implement #deserialize_on_append?', :rbs_skip do
+        before do
+          PgEventstore.configure do |config|
+            config.middlewares = { foo: plain_object_middleware.new('foo') }
+          end
+        end
+
+        it 'applies #deserialize of that middleware' do
+          expect(subject.metadata).to eq('foo' => 'foo')
         end
       end
     end
@@ -478,6 +543,18 @@ RSpec.describe PgEventstore::Client do
 
         it 'applies provided middlewares' do
           expect(subject.metadata).to eq('bar' => 'bar')
+        end
+
+        context 'when the provided middleware opts out of the deserialization on append' do
+          before do
+            PgEventstore.configure do |config|
+              config.middlewares = { bar: read_only_middleware.new('bar') }
+            end
+          end
+
+          it 'skips #deserialize of that middleware' do
+            expect(subject.metadata).to eq('bar' => 'secret-bar')
+          end
         end
       end
     end

--- a/spec/pg_eventstore/middleware_spec.rb
+++ b/spec/pg_eventstore/middleware_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+RSpec.describe PgEventstore::Middleware do
+  let(:middleware_class) do
+    Class.new do
+      include PgEventstore::Middleware
+    end
+  end
+
+  describe '#deserialize_on_append?' do
+    subject { middleware_class.new.deserialize_on_append? }
+
+    it { is_expected.to eq(true) }
+
+    context 'when a middleware overrides it' do
+      let(:middleware_class) do
+        Class.new do
+          include PgEventstore::Middleware
+
+          def deserialize_on_append?
+            false
+          end
+        end
+      end
+
+      it { is_expected.to eq(false) }
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Since v3.0.0, `#append_to_stream` and `#link_to` run `#deserialize` of every applied middleware on the events echoed back from the database. When a middleware's `#deserialize` is expensive — an encryptor calling an external service, a large-payload resolver doing an HTTP round trip — that is pure overhead on the write path, and it happens inside the append transaction.

A middleware can now opt out per middleware:

```ruby
class Encryptor
  include PgEventstore::Middleware

  # Events returned by #append_to_stream/#link_to won't be decrypted
  def deserialize_on_append?
    false
  end

  def serialize(event) = event.data.merge!(encrypt(event.data))
  def deserialize(event) = event.data.merge!(decrypt(event.data))
end
```

- `PgEventstore::Middleware#deserialize_on_append?` defaults to `true`, so there is no behaviour change and no major bump.
- `Client#append_to_stream` and `Client#link_to` build their deserializer from the filtered list. The serializer keeps the full list, so `#serialize` is untouched — an opted-out middleware still writes its data.
- `#read`, `#read_paginated`, `#read_grouped` and subscriptions are unaffected.
- Guarded with `respond_to?`: middlewares only have to respond to `#serialize`/`#deserialize` (see docs/writing_middleware.md), so an object that does not implement the predicate is treated as if it returned `true`.

This replaces the workaround prescribed in the v3.0.0 notes — a subclass with a no-op `#deserialize`, registered under a second config key and selected per call. That workaround leaves two serialize-capable middlewares in the default list, and relies on a hard-coded `middlewares:` list which `Client#middlewares` resolves with `slice`, silently dropping names that are registered differently.

A blanket read/write split was rejected instead: `Middleware::EventTracing#deserialize` is what restores `causation_id`/`correlation_id` onto the echoed event, and `docs/event_tracing.md` feeds the `#append_to_stream` return value straight into `caused_by:`. Some middlewares genuinely must run on the echo, so the axis is per middleware, not per direction.

Drive-by: `Commands::Append` still carried the v2 comment *"It is important to return events in the form they were persisted into the database instead passing them through the configured middlewares"* directly above the line that has done the opposite since v3.

## Notes for review

- One spec — the case where a middleware does not implement the predicate at all — is tagged `:rbs_skip`. `sig/**` types middlewares as `PgEventstore::Middleware` everywhere (`Config#middlewares`, `Client#middlewares`, `EventSerializer`, `EventDeserializer`, `SubscriptionsManager#select_middlewares`), while the docs document plain objects as valid, so the RBS runtime tester rejects one. Resolving that properly means introducing a structural `interface _Middleware` across five sig files; happy to do it here or separately.
- CHANGELOG entry is under `[Unreleased]`; no version bump.

## Test plan

- [x] `./bin/rspec spec/pg_eventstore/middleware_spec.rb spec/pg_eventstore/client_spec.rb spec/pg_eventstore/middleware/event_tracing_spec.rb` — 65 examples, 0 failures
- [x] `event_tracing_spec.rb` passes unchanged — it is the guard that middlewares which need the echo keep deserializing
- [x] Opted-out middleware: skipped on the returned event, still persisted (asserted against the raw stored event read back with `middlewares: []`), still applied on a normal read
- [x] Same coverage for `#link_to`
- [x] Full suite: 2619 examples, 2 failures — `connection_spec.rb:14` (fork recovery) and `basic_runner_spec.rb:1035` (flaky). Both reproduce on `main` without these changes on macOS/arm64 and are unrelated to middlewares
- [x] `bundle exec rubocop` clean on all changed files